### PR TITLE
fixed a bug which caused a build failure

### DIFF
--- a/ruby/test_similarity.rb
+++ b/ruby/test_similarity.rb
@@ -1,4 +1,4 @@
-require 'otama'
+require './otama'
 require 'yaml'
 require 'test/unit'
 require 'pp'


### PR DESCRIPTION
otamaのビルドでRuby拡張を使用するとき、"otama"をrequireできずに発生するビルドの失敗を修正します。
